### PR TITLE
Better way to set worker_processes

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 user  www-data;
-worker_processes  1;
+worker_processes  auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;


### PR DESCRIPTION
As nginx worker_processes is ideally set to the no of cpu cores, as we mostly change server and the no of cpu cores chnages. so nginx has new variable called auto which autodetect number of cpu cores.

Refer: http://nginx.org/en/docs/ngx_core_module.html#worker_processes
